### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kontrast.json
+++ b/org.kde.kontrast.json
@@ -10,6 +10,11 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/share/doc"
+    ],
     "modules": [
         {
             "name": "futuresql",


### PR DESCRIPTION
The installed size reduced from 603.6 kB to 400.4 kB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.